### PR TITLE
feat: add a link resolver

### DIFF
--- a/src/app/[...pagePath]/page.tsx
+++ b/src/app/[...pagePath]/page.tsx
@@ -6,6 +6,7 @@ import * as prismic from "@prismicio/client";
 
 import { createClient } from "@/prismicio";
 import { components } from "@/slices";
+import { linkResolver } from "@/linkResolver";
 
 export const dynamicParams = false;
 
@@ -45,6 +46,8 @@ export async function generateStaticParams() {
   const pages = await client.getAllByType("page");
 
   return pages.map((page) => {
-    return { pagePath: page.url?.split("/").slice(1) };
+    return {
+      pagePath: prismic.asLink(page, { linkResolver })?.split("/").slice(1),
+    };
   });
 }

--- a/src/components/PrismicNextLink.tsx
+++ b/src/components/PrismicNextLink.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import {
+  PrismicNextLink as BasePrismicNextLink,
+  PrismicNextLinkProps,
+} from "@prismicio/next";
+
+import { linkResolver } from "@/linkResolver";
+
+export function PrismicNextLink(props: PrismicNextLinkProps) {
+  return <BasePrismicNextLink linkResolver={linkResolver} {...props} />;
+}

--- a/src/linkResolver.ts
+++ b/src/linkResolver.ts
@@ -1,0 +1,15 @@
+import { FilledContentRelationshipField } from "@prismicio/client";
+
+/**
+ * Characters that separate a UID from its tag. Tagging a UID allows for using a path segment more than once. The tag does not appear in the URL.
+ *
+ * For example, a UID of "my-tag__my-uid" will be converted into "my-uid".
+ */
+const TAG_SEPARATOR = "__";
+
+export function linkResolver(link: FilledContentRelationshipField) {
+  return link.url
+    ?.split("/")
+    .map((part) => part.replace(new RegExp(`.*${TAG_SEPARATOR}`, "g"), ""))
+    .join("/");
+}

--- a/src/slices/RichText/index.tsx
+++ b/src/slices/RichText/index.tsx
@@ -1,10 +1,10 @@
 import type { Content } from "@prismicio/client";
-import { PrismicNextLink } from "@prismicio/next";
 import {
   PrismicRichText,
   SliceComponentProps,
   JSXMapSerializer,
 } from "@prismicio/react";
+import { PrismicNextLink } from "@/components/PrismicNextLink";
 import styles from "./index.module.css";
 
 const components: JSXMapSerializer = {


### PR DESCRIPTION
This PR adds a link resolver to modify URLs.

The link resolver defined in `src/linkResolver.ts` allows an editor to have multiple routes with the same last segment by setting "tagged" UIDs. A tagged UID is one that separates some string and the desired route segment with "__".

For example, the following tagged UIDs construct a corresponding URL. Note that the last segment of the URL is shared with other URLs.

| Tagged UID | URL |
| --- | --- |
| `parent1__child` | `/grandparent/parent1/child` |
| `parent2__child` | `/grandparent/parent2/child` |
| `parent1__child2` | `/grandparent/parent1/child2` |
| `parent2__child2` | `/grandparent/parent2/child2` |
